### PR TITLE
fix:cannot save raw code in editor

### DIFF
--- a/web/ace-editor.js
+++ b/web/ace-editor.js
@@ -68,19 +68,23 @@ export function createAceDomElements(node, editorId) {
             });
         }
         // Mirror code editor text to hidden input widget
+        function waitForElement(){
+            ace
+                .edit(editorId)
+                .getSession()
+                .on("change", (e) => {
+                node.widgets.find((w) => w.name === nodeConfig.hiddenInputId).value =
+                    ace.edit(editorId).getValue();
+            });
+        }
+        //wait for ace editor to be loaded and ready
+
         try {
-            if (ace === null || ace === void 0 ? void 0 : ace.edit) {
-                ace
-                    .edit(editorId)
-                    .getSession()
-                    .on("change", (e) => {
-                    node.widgets.find((w) => w.name === nodeConfig.hiddenInputId).value =
-                        ace.edit(editorId).getValue();
-                });
-            }
+            waitForElement();
         }
         catch (e) {
-            console.debug("[onNodeCreated handler] Error trying to mirror code editor text to hidden input widget", e);
+            console.debug("[onNodeCreated handler] Error trying to mirror code editor text to hidden input widget,try again after 1s", e);
+            setTimeout(waitForElement,1000);
         }
     });
 }


### PR DESCRIPTION
After the recent ComfyUI update, the `createAceDomElements` function fails to locate the DOM element corresponding to `editorId`, likely due to changes in the plugin loading sequence.
As a temporary solution, I've implemented a delayed registration of the editor's `onchange` event. Hope a better solutions for this issue.